### PR TITLE
Changed the digest string to fix auth fail in some devices

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -73,24 +73,23 @@ export default class AxiosDigestAuth {
       const ha2 = crypto.createHash('md5').update(`${opts.method ?? "GET"}:${path}`).digest('hex');
       const response = crypto.createHash('md5').update(`${ha1}:${nonce}:${nonceCount}:${cnonce}:auth:${ha2}`).digest('hex');
 
+      // removed params that shouldnt be quoted
       const params = {
         username: this.username,
         realm,
         nonce,
         uri: path || '',
-        qop: 'auth',
+        // qop: 'auth', 
         algorithm: 'MD5',
         response,
-        nc: nonceCount,
+        // nc: nonceCount,
         cnonce,
       };
 
-      // Hard code params to pick which ones need quotes or not
-      const paramsString = `username="${params.username}", realm="${params.realm}", nonce="${params.nonce}", uri="${params.uri}", cnonce="${params.cnonce}", nc=${params.nc}, qop=auth, response="${params.response}" opaque=""`;
+      const paramsString = Object.entries(params).map(([key, value]) =>  `${key}=${value && quote(value)}`).join(', ');
 
-      // Can cause issues with devices with stick checks
-      // const paramsString = Object.entries(params).map(([key, value]) =>  `${key}=${value && quote(value)}`).join(', ');
-      const authorization = `Digest ${paramsString}`;
+      // Added unquoted params manually
+      const authorization = `Digest ${paramsString}, qop=auth, nc=${nonceCount}, opaque=""`;
 
       if (opts.headers) {
         opts.headers["authorization"] = authorization;

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,11 @@ export default class AxiosDigestAuth {
         cnonce,
       };
 
-      const paramsString = Object.entries(params).map(([key, value]) =>  `${key}=${value && quote(value)}`).join(', ');
+      // Hard code params to pick which ones need quotes or not
+      const paramsString = `username="${params.username}", realm="${params.realm}", nonce="${params.nonce}", uri="${params.uri}", cnonce="${params.cnonce}", nc=${params.nc}, qop=auth, response="${params.response}" opaque=""`;
+
+      // Can cause issues with devices with stick checks
+      // const paramsString = Object.entries(params).map(([key, value]) =>  `${key}=${value && quote(value)}`).join(', ');
       const authorization = `Digest ${paramsString}`;
 
       if (opts.headers) {


### PR DESCRIPTION
The current implementation fails to auth the cameras I own.

So I changed the auth header string formatter in a way that seems to be more aligned with the spec, I compared the headers generated by this auth against ones send by browsers like safari and chrome, and noticed that some parameters where unquoted, so I changed it to reflect that, and the auth worked.